### PR TITLE
fix: CubeTest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DEFAULT_ANVIL_PRIVATE_KEY := 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efca
 
 install:; forge install
 build:; forge build
-test :; forge test --ffi
+test :; forge clean && forge test --ffi
 coverage :; forge coverage --ffi --report debug > coverage-report.txt
 snapshot :; forge snapshot --ffi
 

--- a/test/unit/Cube.t.sol
+++ b/test/unit/Cube.t.sol
@@ -153,6 +153,8 @@ contract CubeTest is Test {
 
         helper = new Helper();
 
+        vm.stopPrank();
+        
         // contract warm up
         _mintCube();
 


### PR DESCRIPTION
### Summary
- [x] Fixed failing tests: `Cube.t.sol`
- [x] Added `forge clean` to testing script so tests can be run consecutively.


---

Before we were attempting to override an ongoing prank with a single `vm.prank` in two places of the [`setUp()`](https://github.com/layer3xyz/cubes/blob/9af92637dad4664d5acdaa8a0c69ace79b60498a/test/unit/Cube.t.sol#L107) function:
1. [`_mintCube();`](https://github.com/layer3xyz/cubes/blob/9af92637dad4664d5acdaa8a0c69ace79b60498a/test/unit/Cube.t.sol#L157):  Line 189 https://github.com/layer3xyz/cubes/blob/9af92637dad4664d5acdaa8a0c69ace79b60498a/test/unit/Cube.t.sol#L164-L191
2. [`vm.prank(ownerPubKey)`](https://github.com/layer3xyz/cubes/blob/9af92637dad4664d5acdaa8a0c69ace79b60498a/test/unit/Cube.t.sol#L160)

---

This results with the following failure when running `make test`:



<details>
  <summary>Failing Test Results</summary>
  <pre>
Ran 5 test suites in 5.63s (16.45s CPU time): 73 tests passed, 1 failed, 0 skipped (74 total tests)

Failing tests:
Encountered 1 failing test in test/unit/Cube.t.sol:CubeTest
[FAIL. Reason: setup failed: cannot override an ongoing prank with a single vm.prank; use vm.startPrank to override the current prank] setUp() (gas: 0)

Encountered a total of 1 failing tests, 73 tests succeeded
make: *** [test] Error 1
  </pre>
</details>

After we add `stopPrank();` we get a passing result:

<details>
  <summary>Passing Test Results</summary>
  <pre>
Ran 5 test suites in 5.57s (16.35s CPU time): 124 tests passed, 0 failed, 0 skipped (124 total tests)
  </pre>
</details>

---

### Code for `setUp()`:

https://github.com/layer3xyz/cubes/blob/9af92637dad4664d5acdaa8a0c69ace79b60498a/test/unit/Cube.t.sol#L141-L162